### PR TITLE
Feature: Grotto info on Home buttons

### DIFF
--- a/js/tabs/home.js
+++ b/js/tabs/home.js
@@ -491,6 +491,11 @@ SharkGame.Home = {
         }
 
         if (SharkGame.Settings.current.showTabHelp) {
+            /* If the created resource has an effect, display it */
+            const generatedResource = SharkGame.ResourceTable?.[Object.keys(actionData.effect.resource)[0]]
+            if (generatedResource.income !== undefined) {
+                    label += `<br><span>Generates: ${r.resourceListToString(generatedResource.income)}</span>`;
+            }
             if (actionData.helpText) {
                 label += "<br><span class='medDesc'>" + actionData.helpText + "</span>";
             }

--- a/js/tabs/home.js
+++ b/js/tabs/home.js
@@ -494,7 +494,7 @@ SharkGame.Home = {
             /* If the created resource has an effect, display it */
             const generatedResource = SharkGame.ResourceTable?.[Object.keys(actionData.effect.resource)[0]]
             if (generatedResource.income !== undefined) {
-                    label += `<br><span>Generates: ${r.resourceListToString(generatedResource.income)}</span>`;
+                    label += `<br><span>Collects ${r.resourceListToString(generatedResource.income)} every second</span>`;
             }
             if (actionData.helpText) {
                 label += "<br><span class='medDesc'>" + actionData.helpText + "</span>";

--- a/js/tabs/home.js
+++ b/js/tabs/home.js
@@ -494,7 +494,7 @@ SharkGame.Home = {
             /* If the created resource has an effect, display it */
             const generatedResource = SharkGame.ResourceTable?.[Object.keys(actionData.effect.resource)[0]]
             if (generatedResource.income !== undefined) {
-                    label += `<br><span>Collects ${r.resourceListToString(generatedResource.income)} every second</span>`;
+                    label += `<br><span>Collects ${r.resourceListToString(generatedResource.income, !enableButton)} every second</span>`;
             }
             if (actionData.helpText) {
                 label += "<br><span class='medDesc'>" + actionData.helpText + "</span>";


### PR DESCRIPTION
Adds an income line to the expanded version of the Home tab buttons. Currently always available, could be locked behind Grotto pretty easily but I'm not that familiar with the codebase yet and didn't want to do it unidiomatically.

Inspired by [this card](https://github.com/spencers145/SharkGame/projects/2#card-52464515).

![localhost_8080_](https://user-images.githubusercontent.com/7687082/104082197-1d8de380-51e9-11eb-840c-0616fb7f4b0f.png)
