### PR TITLE
I finally fixed jittering!

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -267,6 +267,9 @@ pre {
   padding: 5px;
   margin: 5px;
   overflow: hidden;
+  /* overflow anchor fixes jittering! 
+  It disables scroll anchoring where chrome tries to help by scrolling the page */
+  overflow-anchor: none;
 }
 #log h3 {
   display: inline;

--- a/js/log.js
+++ b/js/log.js
@@ -69,16 +69,6 @@ SharkGame.Log = {
                 l.messages.shift();
             }
         }
-
-        l.adjustLogMaxHeight();
-    },
-
-    adjustLogMaxHeight() {
-        // Cuts off messages below rendering limit to significantly cut down on jittering
-        $("#messageList").css(
-            "max-height",
-            SharkGame.Log.messages.reduce((totalHeight, message) => totalHeight + message.innerHeight(), 0) || "100%"
-        );
     },
 
     clearMessages() {


### PR DESCRIPTION
When the base game was developed, scroll anchoring didn't exist. In short, scroll anchoring is where a browser automatically scrolls when something has loaded eg an ad and changes the scroll of a website. Since 2016ish, scroll anchoring got more popular and is in most modern browsers. Sadly, there is a bug in the scroll anchoring algorithm meaning that when the log changes length the page gets scrolled. To opt-out of it, you can add a CSS property to the troublesome container. Also, I removed the adjust log function as it wasn't needed and it itself was buggy (I had spent a while and almost fixed the function before realizing that it didn't need to exist after the jittering was fixed). Tell me if there's something you want me to stylistically change or anything :)